### PR TITLE
Add comprehensive sentences separated by dashes

### DIFF
--- a/snippets/aligns.json
+++ b/snippets/aligns.json
@@ -2,12 +2,12 @@
     "align-content": {
         "body": "align-content:",
         "description": "Alinha linhas flexíveis de containers dentro de um container quando há espaço extra em eixo transversal.",
-        "prefix": "alinhar conteúdo"
+        "prefix": ["alinhar conteúdo", "alinhar-conteúdo"]
     },
     "align-items": {
         "body": "align-items:",
         "description": "Define como o espaço é distribuido entre e ao redor dos itens dentro de um container flexível.",
-        "prefix": "alinhar itens"
+        "prefix": ["alinhar itens", "alinhar-itens"]
     },
     "align-self": {
         "body": "align-self:",

--- a/snippets/animations.json
+++ b/snippets/animations.json
@@ -2,36 +2,36 @@
     "animation-delay": {
         "body": "animation-delay:",
         "description": "Especifíca quando uma animação deve começar.  Você pode começar a animação no futuro, imediatamente ou desde o  início, ou imediatamente e parcialmente através do ciclo de animação.",
-        "prefix": "animação atraso"
+        "prefix": ["animação atraso", "atraso-da-animação"]
     },
     "animation-direction": {
         "body": "animation-direction:",
         "description": "Especifica se uma animação deve ser executada para frente, para trás ou alternada.",
-        "prefix": "animação direção"
+        "prefix": ["animação direção", "direção-da-animação"]
     },
     "animation-duration": {
         "body": "animation-duration:",
         "description": "Especifica o tempo que uma animação deve demorar para concluir um ciclo.",
-        "prefix": "animação duração"
+        "prefix": ["animação duração", "duração-da-animação"]
     },
     "animation-fill-mode": {
         "body": "animation-fill-mode:",
         "description": "Especifica como uma animação CSS deve aplicar estilos ao seu destino antes e depois que ele está sendo executado.",
-        "prefix": "animação modo aplicação estilo"
+        "prefix": ["animação modo aplicação estilo", "modo-de-preenchimento-da-animação"]
     },
     "animation-iteration-count": {
         "body": "animation-iteration-count:",
         "description": "Especifica o número de vezes que um ciclo de animação deve ser reproduzido antes de parar. Se vários valores forem especificados, cada vez que a animação for reproduzida, o próximo valor da lista será usado, retornando ao primeiro valor após o último ser usado.",
-        "prefix": "animação contador iterações"
+        "prefix": ["animação contador iterações", "contador-de-iteração-da-animação"]
     },
     "animation-name": {
         "body": "animation-name:",
         "description": "Especifica uma ou mais animações que devem ser aplicadas a um elemento. Cada nome indica uma regra @keyframes que define os valores da propriedade para a sequência de animação.",
-        "prefix": "animação nome"
+        "prefix": ["animação nome", "nome-da-animação"]
     },
     "animation-play-state": {
         "body": "animation-play-state:",
         "description": "Especifica se uma animação está sendo executada ou pausada.",
-        "prefix": "animação status"
+        "prefix": ["animação status", "status-da-animação"]
     }
 }

--- a/snippets/backgrounds.json
+++ b/snippets/backgrounds.json
@@ -2,46 +2,46 @@
     "background-attachment": {
         "body": "background-attachment:",
         "description": "Se um background-image é especificado, a propriedade CSS background-attachment determina se aquela posição da imagem é fixa com o viewport, ou se irá rolar juntamente com o seu bloco.",
-        "prefix": "fundo anexo"
+        "prefix": ["fundo anexo", "fixação-do-fundo"]
     },
     "background-blend-mode": {
         "body": "background-blend-mode:",
         "description": "Descreve como as imagens de fundo do elemento devem se misturar entre si e a cor de fundo do elemento.",
-        "prefix": "fundo modo mistura"
+        "prefix": ["fundo modo mistura", "modo-de-mistura-do-fundo"]
     },
     "background-clip": {
         "body": "background-clip:",
         "description": "Especifica se o fundo de um elemento, seja cor ou imagem, se extende debaixo de sua borda.",
-        "prefix": "fundo extender na borda"
+        "prefix": ["fundo extender na borda", "extensão-do-fundo"]
     },
     "background-color": {
         "body": "background-color:",
         "description": "Define a cor de fundo.",
-        "prefix": "fundo cor"
+        "prefix": ["fundo cor", "cor-de-fundo"]
     },
     "background-image": {
         "body": "background-image:",
         "description": "Define a imagem de fundo.",
-        "prefix": "fundo imagem"
+        "prefix": ["fundo imagem", "imagem-de-fundo"]
     },
     "background-origin": {
         "body": "background-origin:",
         "description": "Define a área de posicionamento do plano de fundo, isto é, a ponto de origem de uma imagem específica usando a propriedade background-image.",
-        "prefix": "fundo origem"
+        "prefix": ["fundo origem", "ponto-de-origem-do-fundo"]
     },
     "background-position": {
         "body": "background-position:",
         "description": "Define a posição inicial, relativa a posição de fundo na camada definido por background-origin, para cada background image definifo.",
-        "prefix": "fundo posição"
+        "prefix": ["fundo posição", "posição-do-fundo"]
     },
     "background-repeat": {
         "body": "background-repeat:",
         "description": "Define como a imagem de fundo é repetida.",
-        "prefix": "fundo repetir"
+        "prefix": ["fundo repetir", "repetição-do-fundo"]
     },
     "background-size": {
         "body": "background-size:",
         "description": "Especifica o tamanho das imagens de fundo.",
-        "prefix": "fundo tamanho"
+        "prefix": ["fundo tamanho", "tamanho-do-fundo"]
     }
 }

--- a/snippets/borders.json
+++ b/snippets/borders.json
@@ -7,121 +7,121 @@
     "border-bottom": {
         "body": "border-bottom:",
         "description": "Define a borda inferior",
-        "prefix": "borda inferior"
+        "prefix": ["borda inferior", "borda-inferior"]
     },
     "border-bottom-color": {
         "body": "border-bottom-color:",
         "description": "Define a cor da borda inferior",
-        "prefix": "borda inferior cor"
+        "prefix": ["borda inferior cor", "cor-da-borda-inferior"]
     },
     "border-bottom-left-radius": {
         "body": "border-bottom-left-radius:",
         "description": "Define o raio do canto inferior esquerdo",
-        "prefix": "borda raio canto inferior esquerdo"
+        "prefix": ["borda raio canto inferior esquerdo", "raio-do-canto-inferior-esquerdo-da-borda"]
     },
     "border-bottom-right-radius": {
         "body": "border-bottom-right-radius:",
         "description": "Define o raio do canto inferior direito",
-        "prefix": "borda raio canto inferior direito"
+        "prefix": ["borda raio canto inferior direito", "raio-do-canto-inferior-direito-da-borda"]
     },
     "border-bottom-style": {
         "body": "border-bottom-style:",
         "description": "Define o estilo da borda inferior",
-        "prefix": "borda inferior estilo"
+        "prefix": ["borda inferior estilo", "estilo-da-borda-inferior"]
     },
     "border-bottom-width": {
         "body": "border-bottom-width:",
         "description": "Define o comprimento da borda inferior",
-        "prefix": "borda inferior comprimento"
+        "prefix": ["borda inferior comprimento", "comprimento-da-borda-inferior"]
     },
     "border-color": {
         "body": "border-color:",
         "description": "Define a cor da borda",
-        "prefix": "borda cor"
+        "prefix": ["borda cor", "cor-da-borda"]
     },
     "border-left": {
         "body": "border-left:",
         "description": "Define a borda esquerda",
-        "prefix": "borda esquerda"
+        "prefix": ["borda esquerda", "borda-esquerda"]
     },
     "border-left-color": {
         "body": "border-left-color:",
         "description": "Define a cor da borda esquerda",
-        "prefix": "borda esquerda cor"
+        "prefix": ["borda esquerda cor", "cor-da-borda-esquerda"]
     },
     "border-left-style": {
         "body": "border-left-style:",
         "description": "Define o estilo da borda esquerda",
-        "prefix": "borda esquerda estilo"
+        "prefix": ["borda esquerda estilo", "estilo-da-borda-esquerda"]
     },
     "border-left-width": {
         "body": "border-left-width:",
         "description": "Define o comprimento da borda esquerda",
-        "prefix": "borda esquerda comprimento"
+        "prefix": ["borda esquerda comprimento", "comprimento-da-borda-esquerda"]
     },
     "border-radius": {
         "body": "border-radius:",
         "description": "Define o raio dos cantos",
-        "prefix": "borda raio"
+        "prefix": ["borda raio", "raio-da-borda"]
     },
     "border-right": {
         "body": "border-right:",
         "description": "Define a borda direita",
-        "prefix": "borda direita"
+        "prefix": ["borda direita", "borda-direita"]
     },
     "border-right-color": {
         "body": "border-right-color:",
         "description": "Define a cor da borda direita",
-        "prefix": "borda direita cor"
+        "prefix": ["borda direita cor", "cor-da-borda-direita"]
     },
     "border-right-style": {
         "body": "border-right-style:",
         "description": "Define o estilo da borda direita",
-        "prefix": "borda direita estilo"
+        "prefix": ["borda direita estilo", "estilo-da-borda-direita"]
     },
     "border-right-width": {
         "body": "border-right-width:",
         "description": "Define o comprimento da borda direita",
-        "prefix": "borda direita comprimento"
+        "prefix": ["borda direita comprimento", "comprimento-da-borda-direita"]
     },
     "border-style": {
         "body": "border-style:",
         "description": "Define o estilo das 4 bordas",
-        "prefix": "borda estilo"
+        "prefix": ["borda estilo", "estilo-da-borda"]
     },
     "border-top": {
         "body": "border-top:",
         "description": "Define a borda superior",
-        "prefix": "border-top"
+        "prefix": ["borda superior", "borda-superior"]
     },
     "border-top-color": {
         "body": "border-top-color:",
         "description": "Define a cor da borda superior",
-        "prefix": "borda superior cor"
+        "prefix": ["borda superior cor", "cor-da-borda-superior"]
     },
     "border-top-left-radius": {
         "body": "border-top-left-radius:",
         "description": "Define o raio do canto superior esquerdo",
-        "prefix": "borda raio canto superior esquerdo"
+        "prefix": ["borda raio canto superior esquerdo", "raio-do-canto-superior-esquerdo-da-borda"]
     },
     "border-top-right-radius": {
         "body": "border-top-right-radius:",
         "description": "Define o raio do canto superior direito",
-        "prefix": "borda raio canto superior direito"
+        "prefix": ["borda raio canto superior direito", "raio-do-canto-superior-direito-da-borda"]
     },
     "border-top-style": {
         "body": "border-top-style:",
         "description": "Define o estilo da borda superior",
-        "prefix": "borda superior estilo"
+        "prefix": ["borda superior estilo", "estilo-da-borda-superior"]
     },
     "border-top-width": {
         "body": "border-top-width:",
         "description": "Define o comprimento da borda superior",
-        "prefix": "borda superior comprimento"
+        "prefix": ["borda superior comprimento", "comprimento-da-borda-superior"]
     },
     "border-width": {
         "body": "border-width:",
         "description": "Define o comprimento das 4 bordas",
-        "prefix": "borda comprimento"
-    },
+        "prefix": ["borda comprimento", "comprimento-da-borda"]
+    }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -17,12 +17,12 @@
     "font-family": {
         "body": "font-family",
         "description": "Define a família da fonte.",
-        "prefix": "fonte família"
+        "prefix": ["fonte família", "família-de-fonte"]
     },
     "font-size": {
         "body": "font-size",
         "description": "Define o tamanho da fonte.",
-        "prefix": "fonte tamanho"
+        "prefix": ["fonte tamanho", "tamanho-da-fonte"]
     },
     "height": {
         "body": "height:",
@@ -32,12 +32,12 @@
     "letter-spacing": {
         "body": "letter-spacing:",
         "description": "Define o espaçamento entre letras.",
-        "prefix": "espaço letras"
+        "prefix": ["espaço letras", "espaçamento-entre-letras"]
     },
     "line-height": {
         "body": "line-height:",
         "description": "Define a altura da linha.",
-        "prefix": "linha altura"
+        "prefix": ["linha altura", "altura-da-linha"]
     },
     "margin": {
         "body": "margin:",
@@ -47,7 +47,7 @@
     "padding": {
         "body": "padding:",
         "description": "Define o espaçamento interno.",
-        "prefix": "espaço interno"
+        "prefix": ["espaço interno", "espaço-interno"]
     },
     "position": {
         "body": "position:",
@@ -57,12 +57,12 @@
     "text-align": {
         "body": "text-align:",
         "description": "Define o alinhamento do texto.",
-        "prefix": "texto alinhar"
+        "prefix": ["texto alinhar", "alinhar-texto"]
     },
     "text-shadow": {
         "body": "text-shadow:",
         "description": "Define a sombra do texto.",
-        "prefix": "texto sombra"
+        "prefix": ["texto sombra", "sombreamento-do-texto"]
     },
     "transition": {
         "body": "transition:",


### PR DESCRIPTION
New sentences were added as prefixes, changing some of them from strings to lists.
Those sentences are written as used in Portuguese.
Dashes were added as separators to follow CSS convention.

Related to #6 